### PR TITLE
Add scapy_unroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Misc
 - [p0f3plus](https://github.com/FlUxIuS/p0f3plus): an implementation of with extra analysis features
 - [pysap](https://github.com/SecureAuthCorp/pysap): interact with SAP using custom built frames & tools
 - [Responder](https://github.com/SpiderLabs/Responder):  LLMNR, NBT-NS and MDNS poisoner
-- [scapy_unroot](https://github.com/scapy-unroot/scapy_unroot): Tooling to use scapy without root permissions
+- [scapy_unroot](https://github.com/scapy-unroot/scapy_unroot): tooling to use Scapy without root permissions
 - [sshame](https://github.com/HynekPetrak/sshame): tool to brute force SSH public-key authentication
 - [TIDoS Framework](https://github.com/0xInfection/TIDoS-Framework): The Offensive Manual Web Application Penetration Testing Framework
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Misc
 - [p0f3plus](https://github.com/FlUxIuS/p0f3plus): an implementation of with extra analysis features
 - [pysap](https://github.com/SecureAuthCorp/pysap): interact with SAP using custom built frames & tools
 - [Responder](https://github.com/SpiderLabs/Responder):  LLMNR, NBT-NS and MDNS poisoner
+- [scapy_unroot](https://github.com/scapy-unroot/scapy_unroot): Tooling to use scapy without root permissions
 - [sshame](https://github.com/HynekPetrak/sshame): tool to brute force SSH public-key authentication
 - [TIDoS Framework](https://github.com/0xInfection/TIDoS-Framework): The Offensive Manual Web Application Penetration Testing Framework
 


### PR DESCRIPTION
This adds `scapy_unroot` to the list of tools. `scapy_unroot` allows to run `scapy` without root permissions, on systems where users might not have them and setting of netcaps is not advisable. It is achieved by a daemon that runs with root permissions, that dispatches sockets via a UNIX domain socket API to non-root clients, which use special SuperSockets to connect to it.